### PR TITLE
[BUG]: Fixed procedure/function definition and exdecution logic for PostgreSQL

### DIFF
--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -743,33 +743,24 @@ EOD;
         }
 
         $sql = <<<MYSQL
-SELECT ROUTINE_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.ROUTINES {$where}
+SELECT ROUTINE_NAME, ROUTINE_TYPE, DATA_TYPE FROM INFORMATION_SCHEMA.ROUTINES {$where}
 MYSQL;
 
         $rows = $this->connection->select($sql, $bindings);
-
-        $sql = <<<MYSQL
-SELECT r.ROUTINE_NAME
-FROM INFORMATION_SCHEMA.PARAMETERS AS p JOIN INFORMATION_SCHEMA.ROUTINES AS r ON r.SPECIFIC_NAME = p.SPECIFIC_NAME 
-WHERE p.SPECIFIC_SCHEMA = :schema AND (p.PARAMETER_MODE = 'INOUT' OR p.PARAMETER_MODE = 'OUT')
-MYSQL;
-
-        $procedures = $this->selectColumn($sql, $bindings);
 
         $names = [];
         foreach ($rows as $row) {
             $row = array_change_key_case((array)$row, CASE_UPPER);
             $resourceName = array_get($row, 'ROUTINE_NAME');
+            $routineType = array_get($row, 'ROUTINE_TYPE');
             switch (strtoupper($type)) {
                 case 'PROCEDURE':
-                    if (false === array_search($resourceName, $procedures)) {
-                        // only way to determine proc from func is by params??
+                    if ($routineType !== 'PROCEDURE') {
                         continue 2;
                     }
                     break;
                 case 'FUNCTION':
-                    if (false !== array_search($resourceName, $procedures)) {
-                        // only way to determine proc from func is by params??
+                    if ($routineType !== 'FUNCTION') {
                         continue 2;
                     }
                     break;
@@ -872,7 +863,7 @@ MYSQL;
     {
         $paramStr = $this->getRoutineParamString($param_schemas, $values);
 
-        return "SELECT * FROM {$routine->quotedName}($paramStr);";
+        return "CALL {$routine->quotedName}($paramStr);";
     }
 
     /**


### PR DESCRIPTION
PostgreSQL have had official support for Procedures since version 11 released in 2018. Dreamfactorys' implementation for handling functions and procedures dates before that, and handles it based on IN/OUT params for those, which from version PG 11 is no longer accurate. This commit fixes this to correctly look at the ROUTINE_TYPE value in the database information schema to determine if it is an procedure or function.
The important part for this is that procedures needs to be executed using "CALL" where functions are executed using "SELECT", this leads to that the current implementation are not able to execute procedures at all and throws errors when trying to do it, which this commit fixes.
This would be a **breaking change** for applications that calls actual Postgres functions using the incorrect "_proc/" endpoints, which would then need to be updated to call the correct "_func/" endpoint instead.

I have tested and verified that executing both functions and procedures are working after this fix.