### PR TITLE
Laravel 13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,13 @@
   "prefer-stable":     true,
   "require":     {
     "php": "^8.3",
+    "laravel/helpers": "^1.8",
     "dreamfactory/df-database": "~1.4"
   },
   "require-dev": {
     "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
     "phpunit/phpunit": "^11.5.3",
     "orchestra/testbench": "^11.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,13 @@
   "minimum-stability": "dev",
   "prefer-stable":     true,
   "require":     {
-    "dreamfactory/df-database": "~1.3"
+    "php": "^8.3",
+    "dreamfactory/df-database": "~1.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "^10.0"
+    "laravel/framework": "^13.7",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/tests/Security/InoutParamQuotingTest.php
+++ b/tests/Security/InoutParamQuotingTest.php
@@ -92,8 +92,8 @@ class InoutParamQuotingTest extends TestCase
             public function raw($value) { return null; }
             public function selectOne($query, $bindings = [], $useReadPdo = true) { return null; }
             public function scalar($query, $bindings = [], $useReadPdo = true) { return null; }
-            public function select($query, $bindings = [], $useReadPdo = true) { return []; }
-            public function cursor($query, $bindings = [], $useReadPdo = true) { return new \EmptyIterator(); }
+            public function select($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) { return []; }
+            public function cursor($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) { return new \EmptyIterator(); }
             public function insert($query, $bindings = []) { return false; }
             public function update($query, $bindings = []) { return 0; }
             public function delete($query, $bindings = []) { return 0; }


### PR DESCRIPTION
## Summary

Laravel 13 compatibility upgrade for df-sqldb. Composer dep matrix bump + a single test-fixture signature fix for L13's expanded `ConnectionInterface`.

Part of the Laravel 11→13 upgrade campaign. Pilot: dreamfactorysoftware/df-core#162. df-sqldb is the SQL-database base for 11 connector packages (df-mysqldb, df-oracledb, df-sqlsrv, df-firebird, df-ibmdb2, df-informix, df-memsql, df-sqlanywhere, df-snowflake, df-databricks, df-trino).

## Changes

Two commits:
1. `Laravel 13 compatibility` —
   - `composer.json`: `php → ^8.3`, bump `df-database: ~1.3 → ~1.4`, require-dev: laravel/framework ^13.7, phpunit ^11.5.3, orchestra/testbench ^11.0
   - `tests/Security/InoutParamQuotingTest.php`: added `array \$fetchUsing = []` 4th parameter to anonymous-class `ConnectionInterface` stub's `select()` and `cursor()` — Laravel 13's `Illuminate\\Database\\ConnectionInterface` added this parameter; without the stub change PHPUnit 11 fatal-errors at class-definition time on LSP.
2. `Address review: explicit laravel/helpers + align dev tooling` — added `laravel/helpers: ^1.8` to production require (covers 18+ `array_get` sites in src/), aligned `mockery: ^1.6` and `nunomaduro/collision: ^8.6` in require-dev.

## Test plan

- [x] `composer validate --strict` — valid
- [x] `composer install` with df-core / df-system / df-database path-repo aliases — resolves cleanly
- [x] `php -l` clean over src/ + tests/
- [x] `vendor/bin/phpunit tests/Security/InoutParamQuotingTest.php` — 17/17 pass, 47 assertions, under PHPUnit 11.5.55 + L13.7.0
- [x] Stage 2 host-app integration: all 19 df-sqldb namespaced classes autoload under L13.7.0
- [x] Independent code-review-expert pass: PASS (high confidence)

## Notes

- Reviewer verified: df-sqldb does NOT extend `Illuminate\\Database\\Connection`/`Builder`/`Grammar` — lower upgrade risk for downstream connectors.
- Branch based on `origin/master` so `claude-virtual-rel-transactions` (active in-flight saga work) is preserved untouched.
- Wave 2 SQL connectors should expect the same `ConnectionInterface` stub fix in their own test fixtures.