### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,13 @@
   "prefer-stable":     true,
   "require":     {
     "php": "^8.3",
+    "laravel/helpers": "^1.8",
     "dreamfactory/df-database": "~1.4"
   },
   "require-dev": {
     "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
     "phpunit/phpunit": "^11.5.3",
     "orchestra/testbench": "^11.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,13 @@
   "minimum-stability": "dev",
   "prefer-stable":     true,
   "require":     {
-    "dreamfactory/df-database": "~1.3"
+    "php": "^8.3",
+    "dreamfactory/df-database": "~1.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "^10.0"
+    "laravel/framework": "^13.7",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/src/Database/Schema/MySqlSchema.php
+++ b/src/Database/Schema/MySqlSchema.php
@@ -394,23 +394,28 @@ MYSQL;
      */
     protected function getTableConstraints($schema = '')
     {
-        if (is_array($schema)) {
-            $schema = implode("','", $schema);
+        // Normalize to an array of schemas, then build a parameterized
+        // placeholder list so no schema name reaches the SQL via interpolation.
+        $schemas = is_array($schema) ? array_values($schema) : [$schema];
+        $schemas = array_values(array_filter($schemas, fn ($s) => $s !== '' && $s !== null));
+        if (empty($schemas)) {
+            return [];
         }
+        $placeholders = implode(',', array_fill(0, count($schemas), '?'));
 
         $sql = <<<SQL
-SELECT tc.constraint_type, tc.constraint_schema, tc.constraint_name, tc.table_schema, tc.table_name, 
+SELECT tc.constraint_type, tc.constraint_schema, tc.constraint_name, tc.table_schema, tc.table_name,
 kcu.column_name, kcu.referenced_table_schema, kcu.referenced_table_name, kcu.referenced_column_name,
 rc.update_rule, rc.delete_rule
 FROM information_schema.TABLE_CONSTRAINTS tc
-JOIN information_schema.KEY_COLUMN_USAGE kcu ON tc.constraint_schema = kcu.constraint_schema AND 
-tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema AND tc.table_name = kcu.table_name 
-LEFT JOIN information_schema.REFERENTIAL_CONSTRAINTS rc ON tc.constraint_schema = rc.constraint_schema AND 
+JOIN information_schema.KEY_COLUMN_USAGE kcu ON tc.constraint_schema = kcu.constraint_schema AND
+tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema AND tc.table_name = kcu.table_name
+LEFT JOIN information_schema.REFERENTIAL_CONSTRAINTS rc ON tc.constraint_schema = rc.constraint_schema AND
 tc.constraint_name = rc.constraint_name AND tc.table_name = rc.table_name
-WHERE tc.constraint_schema IN ('{$schema}');
+WHERE tc.constraint_schema IN ({$placeholders});
 SQL;
 
-        $results = $this->connection->select($sql);
+        $results = $this->connection->select($sql, $schemas);
         $constraints = [];
         foreach ($results as $row) {
             $row = array_change_key_case((array)$row, CASE_LOWER);

--- a/src/Database/Schema/MySqlSchema.php
+++ b/src/Database/Schema/MySqlSchema.php
@@ -555,10 +555,13 @@ SELECT p.ORDINAL_POSITION, p.PARAMETER_MODE, p.PARAMETER_NAME, p.DATA_TYPE, p.CH
 p.NUMERIC_PRECISION, p.NUMERIC_SCALE
 FROM INFORMATION_SCHEMA.PARAMETERS AS p 
 JOIN INFORMATION_SCHEMA.ROUTINES AS r ON r.SPECIFIC_NAME = p.SPECIFIC_NAME
-WHERE r.ROUTINE_NAME = '{$holder->resourceName}' AND r.ROUTINE_SCHEMA = '{$holder->schemaName}'
+WHERE r.ROUTINE_NAME = :routineName AND r.ROUTINE_SCHEMA = :schemaName
 MYSQL;
 
-        $params = $this->connection->select($sql);
+        $params = $this->connection->select($sql, [
+            ':routineName' => $holder->resourceName,
+            ':schemaName'  => $holder->schemaName,
+        ]);
         foreach ($params as $row) {
             $row = array_change_key_case((array)$row, CASE_UPPER);
             $name = ltrim(array_get($row, 'PARAMETER_NAME'), '@'); // added on by some drivers, i.e. @name

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -355,22 +355,25 @@ SQL;
      */
     protected function getTableConstraints($schema = '')
     {
-        if (is_array($schema)) {
-            $schema = implode("','", $schema);
+        $schemas = is_array($schema) ? array_values($schema) : [$schema];
+        $schemas = array_values(array_filter($schemas, fn ($s) => $s !== '' && $s !== null));
+        if (empty($schemas)) {
+            return [];
         }
+        $placeholders = implode(',', array_fill(0, count($schemas), '?'));
 
         $sql = <<<SQL
-SELECT tc.constraint_type, tc.constraint_schema, tc.constraint_name, tc.constraint_type, tc.table_schema, tc.table_name, kcu.column_name, 
-kcu2.table_schema as referenced_table_schema, kcu2.table_name as referenced_table_name, kcu2.column_name as referenced_column_name, 
+SELECT tc.constraint_type, tc.constraint_schema, tc.constraint_name, tc.constraint_type, tc.table_schema, tc.table_name, kcu.column_name,
+kcu2.table_schema as referenced_table_schema, kcu2.table_name as referenced_table_name, kcu2.column_name as referenced_column_name,
 rc.update_rule, rc.delete_rule
 FROM information_schema.TABLE_CONSTRAINTS tc
 JOIN information_schema.KEY_COLUMN_USAGE kcu ON tc.constraint_schema = kcu.constraint_schema AND tc.constraint_name = kcu.constraint_name AND tc.table_name = kcu.table_name
 LEFT JOIN information_schema.REFERENTIAL_CONSTRAINTS rc ON tc.constraint_schema = rc.constraint_schema AND tc.constraint_name = rc.constraint_name
 LEFT JOIN information_schema.KEY_COLUMN_USAGE kcu2 ON rc.unique_constraint_schema = kcu2.constraint_schema AND rc.unique_constraint_name = kcu2.constraint_name
-WHERE tc.constraint_schema IN ('{$schema}');
+WHERE tc.constraint_schema IN ({$placeholders});
 SQL;
 
-        $results = $this->connection->select($sql);
+        $results = $this->connection->select($sql, $schemas);
         $constraints = [];
         foreach ($results as $row) {
             $row = array_change_key_case((array)$row, CASE_LOWER);

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -418,13 +418,15 @@ SELECT table_name, table_schema FROM information_schema.tables WHERE table_type 
 EOD;
 
         if (!empty($schema)) {
-            $sql .= " AND table_schema = '$schema'";
+            $sql .= " AND table_schema = ?";
         }
 
         $defaultSchema = self::DEFAULT_SCHEMA;
         $addSchema = (!empty($schema) && ($defaultSchema !== $schema));
 
-        $rows = $this->connection->select($sql);
+        $rows = !empty($schema)
+            ? $this->connection->select($sql, [$schema])
+            : $this->connection->select($sql);
 
         $names = [];
         foreach ($rows as $row) {
@@ -463,13 +465,15 @@ SELECT all_views.table_name, all_views.table_schema
 EOD;
 
         if (!empty($schema)) {
-            $sql .= " AND table_schema = '$schema'";
+            $sql .= " AND table_schema = ?";
         }
 
         $defaultSchema = self::DEFAULT_SCHEMA;
         $addSchema = (!empty($schema) && ($defaultSchema !== $schema));
 
-        $rows = $this->connection->select($sql);
+        $rows = !empty($schema)
+            ? $this->connection->select($sql, [$schema])
+            : $this->connection->select($sql);
 
         $names = [];
         foreach ($rows as $row) {
@@ -835,10 +839,13 @@ SELECT p.ORDINAL_POSITION, p.PARAMETER_MODE, p.PARAMETER_NAME, p.DATA_TYPE, p.CH
 p.NUMERIC_PRECISION, p.NUMERIC_SCALE
 FROM INFORMATION_SCHEMA.PARAMETERS AS p 
 JOIN INFORMATION_SCHEMA.ROUTINES AS r ON r.SPECIFIC_NAME = p.SPECIFIC_NAME
-WHERE r.ROUTINE_NAME = '{$holder->resourceName}' AND r.ROUTINE_SCHEMA = '{$holder->schemaName}'
+WHERE r.ROUTINE_NAME = :routineName AND r.ROUTINE_SCHEMA = :schemaName
 MYSQL;
 
-        $params = $this->connection->select($sql);
+        $params = $this->connection->select($sql, [
+            ':routineName' => $holder->resourceName,
+            ':schemaName'  => $holder->schemaName,
+        ]);
         foreach ($params as $row) {
             $row = array_change_key_case((array)$row, CASE_UPPER);
             $name = ltrim(array_get($row, 'PARAMETER_NAME'), '@'); // added on by some drivers, i.e. @name

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -297,6 +297,13 @@ class PostgresSchema extends SqlSchema
             $adsrc = $version >= 12 ? 'pg_get_expr(d.adbin, d.adrelid) AS adsrc' : 'd.adsrc';
             $sql = <<<SQL
 SELECT a.attname, LOWER(format_type(a.atttypid, a.atttypmod)) AS type, $adsrc, a.attnotnull, a.atthasdef,
+	EXISTS (
+		SELECT 1
+		FROM pg_index i
+		WHERE i.indrelid = a.attrelid
+			AND i.indisprimary
+			AND a.attnum = ANY(i.indkey)
+	) AS is_primary_key,
 	pg_catalog.col_description(a.attrelid, a.attnum) AS comment
 FROM pg_attribute a LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
 WHERE a.attnum > 0 AND NOT a.attisdropped

--- a/tests/Security/InoutParamQuotingTest.php
+++ b/tests/Security/InoutParamQuotingTest.php
@@ -92,8 +92,8 @@ class InoutParamQuotingTest extends TestCase
             public function raw($value) { return null; }
             public function selectOne($query, $bindings = [], $useReadPdo = true) { return null; }
             public function scalar($query, $bindings = [], $useReadPdo = true) { return null; }
-            public function select($query, $bindings = [], $useReadPdo = true) { return []; }
-            public function cursor($query, $bindings = [], $useReadPdo = true) { return new \EmptyIterator(); }
+            public function select($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) { return []; }
+            public function cursor($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) { return new \EmptyIterator(); }
             public function insert($query, $bindings = []) { return false; }
             public function update($query, $bindings = []) { return 0; }
             public function delete($query, $bindings = []) { return 0; }

--- a/tests/Security/SchemaInterpolationTest.php
+++ b/tests/Security/SchemaInterpolationTest.php
@@ -27,7 +27,7 @@ class SchemaInterpolationTest extends TestCase
             $end = strpos($contents, "\n    /**", $start + 10);
             $body = substr($contents, $start, $end === false ? null : ($end - $start));
 
-            $this->assertStringNotContainsString("table_schema = '$schema'", $body);
+            $this->assertStringNotContainsString("table_schema = '\$schema'", $body);
             $this->assertTrue(
                 str_contains($body, 'table_schema = ?') || str_contains($body, 'table_schema = :schema'),
                 $needle . ' must use a bound schema placeholder'

--- a/tests/Security/SchemaInterpolationTest.php
+++ b/tests/Security/SchemaInterpolationTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace DreamFactory\Core\SqlDb\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: Mysql + Postgres getTableConstraints() must use parameterized
+ * bindings, not implode("','", $schema) interpolation.
+ *
+ * Phase 2 audit found the same `IN ('{$schema}')` pattern that was fixed
+ * for SQL Server in df-sqlsrv replicated in MySQL and Postgres drivers.
+ * The schema parameter flows from the API caller through the schema
+ * resource layer; even if the typical caller is admin, the interpolation
+ * pattern is a future-bug magnet — any change that widens the input path
+ * becomes SQLi.
+ *
+ * After the fix, both drivers use ? placeholders + a bindings array
+ * passed to connection->select(), matching the fix already applied in
+ * df-sqlsrv.
+ */
+class SchemaInterpolationTest extends TestCase
+{
+    /**
+     * @dataProvider driverProvider
+     */
+    public function testDriverUsesParameterizedSchema(string $relativePath): void
+    {
+        $absPath = __DIR__ . '/../../' . $relativePath;
+        $this->assertFileExists($absPath);
+        $contents = file_get_contents($absPath);
+
+        // Slice getTableConstraints body
+        $start = strpos($contents, 'function getTableConstraints');
+        $this->assertNotFalse($start);
+        $end = strpos($contents, "\n    /**", $start + 10);
+        $body = substr($contents, $start, $end === false ? null : ($end - $start));
+
+        // Forbid the implode("','", $schema) interpolation pattern.
+        $this->assertDoesNotMatchRegularExpression(
+            "/implode\s*\(\s*[\"']'\\\\?,\\\\?'[\"']\s*,\s*\\\$schema\s*\)/",
+            $body,
+            'getTableConstraints() must not interpolate schema names via implode'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            "/IN\s*\(\s*'\{\\\$schema\}'\s*\)/",
+            $body,
+            "getTableConstraints() must not interpolate \$schema into IN clause"
+        );
+        // Require parameterized form.
+        $this->assertMatchesRegularExpression(
+            '/\$placeholders\s*=\s*implode\s*\(\s*[\'\"],[\'\"]\s*,\s*array_fill/',
+            $body,
+            'getTableConstraints() must build a placeholder list and pass bindings'
+        );
+    }
+
+    public static function driverProvider(): array
+    {
+        return [
+            'MySqlSchema'    => ['src/Database/Schema/MySqlSchema.php'],
+            'PostgresSchema' => ['src/Database/Schema/PostgresSchema.php'],
+        ];
+    }
+}

--- a/tests/Security/SchemaInterpolationTest.php
+++ b/tests/Security/SchemaInterpolationTest.php
@@ -5,57 +5,73 @@ namespace DreamFactory\Core\SqlDb\Tests\Security;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Security: Mysql + Postgres getTableConstraints() must use parameterized
- * bindings, not implode("','", $schema) interpolation.
+ * Security: schema/routine metadata lookups in Mysql + Postgres drivers must
+ * use parameterized bindings instead of interpolating caller-influenced values.
  *
- * Phase 2 audit found the same `IN ('{$schema}')` pattern that was fixed
- * for SQL Server in df-sqlsrv replicated in MySQL and Postgres drivers.
- * The schema parameter flows from the API caller through the schema
- * resource layer; even if the typical caller is admin, the interpolation
- * pattern is a future-bug magnet — any change that widens the input path
- * becomes SQLi.
- *
- * After the fix, both drivers use ? placeholders + a bindings array
- * passed to connection->select(), matching the fix already applied in
- * df-sqlsrv.
+ * Phase 2 audit fixed getTableConstraints(). Follow-up review found the same
+ * interpolation pattern still present in:
+ *  - routine parameter introspection (loadParameters)
+ *  - Postgres schema-scoped table/view discovery
  */
 class SchemaInterpolationTest extends TestCase
 {
+    public function testPostgresSchemaScopedDiscoveryUsesBindings(): void
+    {
+        $absPath = __DIR__ . '/../../src/Database/Schema/PostgresSchema.php';
+        $this->assertFileExists($absPath);
+        $contents = file_get_contents($absPath);
+
+        foreach (['function getTableNames', 'function getViewNames'] as $needle) {
+            $start = strpos($contents, $needle);
+            $this->assertNotFalse($start, $needle . ' must exist');
+            $end = strpos($contents, "\n    /**", $start + 10);
+            $body = substr($contents, $start, $end === false ? null : ($end - $start));
+
+            $this->assertStringNotContainsString("table_schema = '$schema'", $body);
+            $this->assertTrue(
+                str_contains($body, 'table_schema = ?') || str_contains($body, 'table_schema = :schema'),
+                $needle . ' must use a bound schema placeholder'
+            );
+        }
+    }
+
     /**
-     * @dataProvider driverProvider
+     * @dataProvider loadParametersProvider
      */
-    public function testDriverUsesParameterizedSchema(string $relativePath): void
+    public function testRoutineParameterLookupUsesBindings(string $relativePath): void
     {
         $absPath = __DIR__ . '/../../' . $relativePath;
         $this->assertFileExists($absPath);
         $contents = file_get_contents($absPath);
 
-        // Slice getTableConstraints body
-        $start = strpos($contents, 'function getTableConstraints');
+        $start = strpos($contents, 'function loadParameters');
         $this->assertNotFalse($start);
-        $end = strpos($contents, "\n    /**", $start + 10);
+        $end = strpos($contents, "\n    protected function", $start + 10);
         $body = substr($contents, $start, $end === false ? null : ($end - $start));
 
-        // Forbid the implode("','", $schema) interpolation pattern.
         $this->assertDoesNotMatchRegularExpression(
-            "/implode\s*\(\s*[\"']'\\\\?,\\\\?'[\"']\s*,\s*\\\$schema\s*\)/",
+            "/ROUTINE_NAME = '\{\\\$holder->resourceName\}'/",
             $body,
-            'getTableConstraints() must not interpolate schema names via implode'
+            'loadParameters() must not interpolate routine names directly into SQL'
         );
         $this->assertDoesNotMatchRegularExpression(
-            "/IN\s*\(\s*'\{\\\$schema\}'\s*\)/",
+            "/ROUTINE_SCHEMA = '\{\\\$holder->schemaName\}'/",
             $body,
-            "getTableConstraints() must not interpolate \$schema into IN clause"
+            'loadParameters() must not interpolate schema names directly into SQL'
         );
-        // Require parameterized form.
         $this->assertMatchesRegularExpression(
-            '/\$placeholders\s*=\s*implode\s*\(\s*[\'\"],[\'\"]\s*,\s*array_fill/',
+            '/ROUTINE_NAME = :routineName|ROUTINE_NAME = \?/',
             $body,
-            'getTableConstraints() must build a placeholder list and pass bindings'
+            'loadParameters() must use a parameter placeholder for routine name'
+        );
+        $this->assertMatchesRegularExpression(
+            '/ROUTINE_SCHEMA = :schemaName|ROUTINE_SCHEMA = \?/',
+            $body,
+            'loadParameters() must use a parameter placeholder for schema name'
         );
     }
 
-    public static function driverProvider(): array
+    public static function loadParametersProvider(): array
     {
         return [
             'MySqlSchema'    => ['src/Database/Schema/MySqlSchema.php'],


### PR DESCRIPTION
## Release prep: cut develop into master/main

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

### Verification

The develop HEAD on this branch is the SHA locked into the L13/PHP 8.5
test bundle that the team has been smoking. **Full end-to-end smoke
passed 2026-05-26**: PHP 8.5.5, Laravel 13.11.2, `df:setup` seeders,
admin login → JWT, service-type registration (81 types), Postgres
schema introspection + CRUD, OpenAPI generation.

### Coordinated release PRs

This is one of ~26 coordinated `develop → master/main` PRs opened
together as the release cut. Suggested merge order:

1. **Foundation**: df-core → df-system → df-user → df-database
2. **Connectors**: df-sqldb, df-sqlsrv, df-mongodb, df-oracledb, df-snowflake, df-soap, df-salesforce, df-script
3. **Auth**: df-oauth → df-adldap, df-azure-ad, df-oidc, df-saml
4. **Services**: df-email, df-file, df-cache, df-limits, df-logger, df-scheduler
5. **AI tier**: df-ai → df-ai-chat → df-mcp-server
6. **Admin UI**: df-admin-interface
7. **Host app**: dreamfactory/dreamfactory (released last)

### Customer upgrade path

In-place on Docker / managed Linux packages; blue-green strongly
recommended on Windows + custom-PHP-extension installs. Pre-flight
checklist in the release notes.
